### PR TITLE
setup auto update label

### DIFF
--- a/.github/workflows/add_label_auto-update_on_pr.yml
+++ b/.github/workflows/add_label_auto-update_on_pr.yml
@@ -12,3 +12,12 @@ jobs:
       uses: 'sakshi-devotess/github-action/.github/workflows/add-label-auto-update.yml@main'
       with:
         label: "auto-update"
+
+    auto-update:
+      uses: 'sakshi-devotess/github-action/.github/workflows/auto-update-head-branch.yml@main'
+      with:
+        base_branch: "main"
+        label_name: "auto-update"
+        repository : ${{ github.repository }}
+      secrets:
+        pat_token : ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add_label_auto-update_on_pr.yml
+++ b/.github/workflows/add_label_auto-update_on_pr.yml
@@ -1,0 +1,13 @@
+name: Add label auto-update to new pull request
+
+on:
+    pull_request:
+        types: [opened, reopened]
+        branches:
+            - development
+
+jobs:
+    add-label-auto-update:
+      uses: 'sakshi-devotess/github-action/.github/workflows/add-label-auto-update.yml@main'
+      with:
+        label: "auto-update"

--- a/.github/workflows/add_label_auto-update_on_pr.yml
+++ b/.github/workflows/add_label_auto-update_on_pr.yml
@@ -2,9 +2,9 @@ name: Add label auto-update to new pull request
 
 on:
     pull_request:
-        types: [opened, reopened]
+        types: [opened, ready_for_review, reopened, edited, synchronize]
         branches:
-            - development
+            - main
 
 jobs:
     add-label-auto-update:

--- a/.github/workflows/add_label_auto-update_on_pr.yml
+++ b/.github/workflows/add_label_auto-update_on_pr.yml
@@ -12,12 +12,3 @@ jobs:
       uses: 'sakshi-devotess/github-action/.github/workflows/add-label-auto-update.yml@main'
       with:
         label: "auto-update"
-
-    auto-update:
-      uses: 'sakshi-devotess/github-action/.github/workflows/auto-update-head-branch.yml@main'
-      with:
-        base_branch: "main"
-        label_name: "auto-update"
-        repository : ${{ github.repository }}
-      secrets:
-        pat_token : ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add_label_auto-update_on_pr.yml
+++ b/.github/workflows/add_label_auto-update_on_pr.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
     add-label-auto-update:
+      permissions : write-all
       uses: 'sakshi-devotess/github-action/.github/workflows/add-label-auto-update.yml@main'
       with:
         label: "auto-update"

--- a/.github/workflows/development_push.yml
+++ b/.github/workflows/development_push.yml
@@ -1,0 +1,30 @@
+name: 'Development Push Workflow'
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    branches: [main]
+
+jobs:
+  # deploy:
+  #   uses: 'SaaS-Innova/github-action/.github/workflows/frontend-development.yml@main'
+  #   with:
+  #     hostname: '46.246.49.208'
+  #     user: 'accounts'
+  #     target: 'staging'
+  #     destination: '~/repos/BoilerPlateReact'
+  #     fingerprint: '46.246.49.208 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCjaWGdnEELkQOloke/aWZMkQ1MerQHYiGnK/z8TXu4i7GE0yIk6HwfcfQftkIzY4ypROGR3waz9wUZkE59Fw4uIeM3PP1EIbqOQk3BI9LGBPkbWXDQyNiqBwFOHj4dWtIIWV+CIuwY7jrPf3dC7fpt9cCORPgHa3eD8pymGs4PA1gKXL9e3lq0L6aenl1uPLldXU5x4+F0HvHYyydc7H1bKijrxZ1wY+1ZCM8l/wZ4V6FxE3bFwZDxDSxfH3Wq9FSgTYZrgRmKSPw1IWZD+FSAx1Naz+HWuEVIhoM/uJKPVO/wUyjKFCKO0To3xEXg0fheVh06+zbxxPAKUjy/H/Wyxv65FjzVuua5Pd89wNkKOfzwPOPE6XuTMvCEYnJ7SggwpaFZJB6RjU+IeAHT/SC1TlBIS3fcaAmdQx4yapr5y7rC1qDGf9pAG0kTv4p4zu3QpJa+KS8mvQupKFuXAx7SpPrTxAOBzT8+czeRfcvXWxCO4eeatOD70C+Af9l+a7k='
+  #     pm2_name: 'BoilerPlateFE'
+  #   secrets:
+  #     password: ${{ secrets.STG_PASSWORD }}
+  #     dotenv_key: ${{ secrets.STG_DOTENV_KEY }}
+  
+  auto-update:
+    uses: 'sakshi-devotess/github-action/.github/workflows/auto-update-head-branch.yml@main'
+    with:
+      base_branch: "main"
+      label_name: "auto-update"
+      repository : ${{ github.repository }}
+    secrets:
+      pat_token : ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/development_push.yml
+++ b/.github/workflows/development_push.yml
@@ -1,10 +1,9 @@
-name: 'Development Push Workflow'
+name: Auto Update Head Branch
 
 on:
-  push:
-    branches: [main]
-  workflow_dispatch:
-    branches: [main]
+    push:
+        branches:
+            - 'main'
 
 jobs:
   # deploy:
@@ -20,6 +19,77 @@ jobs:
   #     password: ${{ secrets.STG_PASSWORD }}
   #     dotenv_key: ${{ secrets.STG_DOTENV_KEY }}
   
+  auto-update222:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check Out Code
+              uses: actions/checkout@v3
+              with:
+                  token: ${{ secrets.ROHIT_PAT }}
+              env:
+                  PAT: ${{ secrets.ROHIT_PAT }}
+
+            - name: Get Oldest Pull Request
+              id: get-oldest-pr
+              run: |
+                  GITHUB_TOKEN=${{ secrets.ROHIT_PAT }}
+                  GITHUB_REPOSITORY=${{ github.repository }}
+
+                  echo "Use the GitHub API to fetch the oldest open pull request targeting 'development' branch"
+                  oldest_pr_data=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+                    "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls?state=open&base=development&sort=created&direction=asc")
+
+                    echo "Parse the JSON data to get the head branch name of the oldest pull request"
+                    oldest_pr_head_branch=$(echo "$oldest_pr_data" | jq -r '.[] | select(.labels[].name == "auto-update" and .state == "open" and .auto_merge) | .head.ref' | head -n 1)
+
+                  # Debugging output
+                  echo "oldest_pr_head_branch: $oldest_pr_head_branch"
+
+                  # Check if the oldest pull request number is set
+                  if [ -n "$oldest_pr_head_branch" ]; then
+                    echo "set the SKIP_UPDATE output variable"
+                    echo "SKIP_UPDATE=false" >> $GITHUB_OUTPUT # Set the SKIP_UPDATE output variable
+                    echo "set the HEAD_BRANCH_NAME environment variable"
+                    echo "HEAD_BRANCH_NAME=$oldest_pr_head_branch" >> $GITHUB_ENV # Set the HEAD_BRANCH environment variable
+                  else
+                    echo "No open pull requests founds with 'auto-update' label and 'auto_merge' status."
+                  fi
+
+            - name: Ensure Current Branch is Up-to-Date and Conflict-Free
+              env:
+                  BASE_BRANCH: development
+              if: success() && steps.get-oldest-pr.outputs.SKIP_UPDATE == 'false'
+              run: |
+                  HEAD_BRANCH=$HEAD_BRANCH_NAME # Use the HEAD_BRANCH_NAME environment variable
+
+                  # Debugging output
+                  echo "BASE_BRANCH: $BASE_BRANCH"
+                  echo "HEAD_BRANCH: $HEAD_BRANCH"
+
+                  echo "Set git user"
+                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                  git config --global user.name "Auto Update Bot"
+
+                  echo "Fetch the latest changes from the remote"
+                  git fetch origin
+                  echo "Checkout base branch"
+                  git checkout "$BASE_BRANCH"
+                  echo "Checkout head branch"
+                  git checkout "$HEAD_BRANCH"
+
+                  echo "Check merge-base.."
+                  if git merge-base --is-ancestor "$BASE_BRANCH" "$HEAD_BRANCH"; then
+                    echo "Branch $HEAD_BRANCH is out of date or has conflicts. Manual intervention required."
+                  else
+                    # The branch is up-to-date and there are no conflicts
+                    echo "Branch $HEAD_BRANCH is up-to-date. Proceeding with the auto-update..."
+                    git pull --no-edit --no-rebase origin "$BASE_BRANCH" --allow-unrelated-histories
+                    echo "Pushing changes to $HEAD_BRANCH"
+                    git push origin "$HEAD_BRANCH"            
+                  fi
+                  echo "Completed..."
+                  exit 0
+
   auto-update:
     uses: 'sakshi-devotess/github-action/.github/workflows/auto-update-head-branch.yml@main'
     with:


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate labeling and branch updates for pull requests. The most important changes include adding a workflow to automatically label new pull requests and another workflow to handle branch updates on pushes to the main branch.

New GitHub Actions workflows:

* [`.github/workflows/add_label_auto-update_on_pr.yml`](diffhunk://#diff-ea74502199abab7a4713319a35e96b4325883aff5adb1160197f2c87b1dd28d7R1-R13): Added a workflow to automatically add the "auto-update" label to new or reopened pull requests targeting the `development` branch.
* [`.github/workflows/development_push.yml`](diffhunk://#diff-e725be55e73ce9ddb78f7de2b64b88cbb282283504d9ca98e3d65a80c7029d7aR1-R30): Added a workflow to handle branch updates by using the `auto-update-head-branch.yml` action on pushes to the main branch, and commented out the deployment job.